### PR TITLE
Add input field to specify URL or leave blank to use current page

### DIFF
--- a/frontend/popup.html
+++ b/frontend/popup.html
@@ -1,29 +1,37 @@
 <!doctype html>
 <html lang="en">
-    <head>
+
+<head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Bootstrap demo</title>
         <link href="popup.css" rel="stylesheet">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+                integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+                crossorigin="anonymous">
         <style>
                 #result {
                         display: none;
                 }
         </style>
-    </head>
-    <body>
+</head>
+
+<body>
         <div style="padding: 20px;">
                 <h3 style="margin-top: 0;">Website Description Teller</h3>
                 <p style="color: gray; font-size: 14px;">Gives you the description of any website</p>
                 <div style="text-align: center;">
-                        <input type="text" class="form-control" id="urlInput" placeholder="API URL" style="margin-bottom: 20px;" value="http://localhost:8000/check_url">
-                        <button class="btn btn-md btn-info" id="checkButton">Check Current URL</button>
+                        <input type="text" id="url" style="margin: 10px;">
+                        <button class="btn btn-md btn-info" id="checkButton">Check URL (Leave blank to use the current
+                                URL)</button>
                         <div id="result" class="alert" role="alert" style="margin-top: 20px;"></div>
                 </div>
         </div>
-        
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+                integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+                crossorigin="anonymous"></script>
         <script src="popup.js"></script>
-    </body>
+</body>
+
 </html>

--- a/frontend/popup.js
+++ b/frontend/popup.js
@@ -1,16 +1,22 @@
-document.getElementById('checkButton').addEventListener('click', async () => {    
+document.getElementById('checkButton').addEventListener('click', async () => {
     const resultDiv = document.getElementById('result');
-    const apiUrl = document.getElementById('urlInput');
     resultDiv.style.display = 'none';
-    let [tab] = await chrome.tabs.query({active: true, currentWindow: true});
-    if (tab.url) {
+    let url = ""
+    if (document.getElementById("url").value) {
+        url = document.getElementById("url").value;
+
+    } else {
+        let [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        url = tab.url;
+    }
+    if (url) {
         try {
-            const response = await fetch(apiUrl.value, {
+            const response = await fetch('http://localhost:8000/check_url', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({url: tab.url}),
+                body: JSON.stringify({ url: url }),
             });
             const data = await response.json();
             resultDiv.textContent = `${data.result}`;


### PR DESCRIPTION
Previously, the tool only worked on the current page, which meant users had to open the website first in order to check its content or description. This update adds an input field that allows users to directly specify the URL of any website they want to check, without having to open it manually. If the input is left blank, the tool will use the current page URL.
This makes the feature more flexible and logical for users who want to analyze a website without visiting it first.